### PR TITLE
Pacmanfile & Secondary target features, fixed linter warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ privileges in .config and ~
 Roadmap
 --
 
+**TODO: Add pacmanfile option**
+
 **TODO: Create tar, run tarsplit, compress split tar file(s)**
 
 **TODO: Verify chunk sizes**
@@ -48,3 +50,7 @@ Roadmap
 **TODO: Compress chunks after tarsplit**
 
 **TODO: Create testing**
+
+**TODO: Support external target locations**
+
+**TODO: Add sha512 hashing for temp files**

--- a/default_conf
+++ b/default_conf
@@ -3,16 +3,16 @@
 #This defines the compression level for gzip at the end of the script, acceptable values are between 1-9
 export COMPRESSION_LEVEL=-6
 
-#Will be used in future releases
-export EXTERNAL_STORAGE=
+#WIP
+export EXTERNAL_STORAGE=smb://192.168.1.101/jhelmer/tar-pit
 
-#Will be used in future releases
+#WIP
 export DVD_DRIVE=/mnt/cdrom
 
-#Will be used in future releases
+#WIP
 export AUTO_BURN=false
 
-#Will be used in future releases
+#WIP
 export AUTO_CP_TO_EXTERN=false
 
 #Path to the file which lists all files to be backed up
@@ -27,6 +27,14 @@ export COMP_TAR=$(date '+%m-%d-%y').tar.gz
 
 #Directory where output files are stored
 export TARGET=$HOME/tar-pit
+#Leave SECONDARY_TARGET as "null" if not in use
+#format this as "/dev/devicename/folder; E.g. /dev/sda1/tar-pit-backups"
+export SECONDARY_TARGET=null
 
 #Split files to fit on 7.9 GB dvd's
+#Not functional
 export SPLIT=false
+
+#Add dump of current programs if pacmanfile is installed on arch systems
+# $HOME/.config must be backed up in order to save this
+export pacmanfile=false

--- a/tar-pit.sh
+++ b/tar-pit.sh
@@ -6,7 +6,7 @@ CONVERSION=1074000
 if [ -d "$CONFIG_DIR" ] ; then
 	echo "Configuration file exists"
 else
-	mkdir $CONFIG_DIR
+	mkdir "$CONFIG_DIR"
 fi
 
 if [ -e "$USER_CONFIG" ] ; then
@@ -14,7 +14,7 @@ if [ -e "$USER_CONFIG" ] ; then
 	source $HOME/.config/tar-pit/conf
 else
 	echo "No user modified config found, creating a default"
-	touch $USER_CONFIG
+	touch "$USER_CONFIG"
 
 	echo "
 	#!/bin/bash
@@ -49,7 +49,7 @@ else
 
 	#Split files to fit on 7.9 GB dvd's
 	export SPLIT=false
-	" >> $USER_CONFIG
+	" >> "$USER_CONFIG"
 
 fi
 
@@ -66,6 +66,20 @@ fi
 
 echo "Configuration complete"
 echo "home_index updated"
+
+#Pacmanfile option for arch users
+if [ pacmanfile != false ] ; then
+	if pacman -Qqm pacmanfile ; then
+		echo "pacmanfile is installed"
+	else
+		echo "please install pacmanfile"
+	fi
+	pacmanfile dump
+	echo "pacmanfile dump complete. Your current packages have been written to $HOME/.config/pacmanfile/pacmanfile-dumped.txt"
+else
+	echo "Pacmanfile option not selected"
+fi
+
 
 #Read from either default or user config, then tar respective selections; exit 1 for a failure
 cd $HOME/.config/tar-pit || exit 1
@@ -94,7 +108,7 @@ else
   mkdir $TARGET
 fi
 
-mv "$TAR" $TARGET	#TODO; add pv bar
+mv "$TAR" $TARGET
 echo "tar file completed"
 echo "$TAR moved to $HOME/tar-pit"
 
@@ -128,19 +142,23 @@ if [ "$SPLIT" = true ]; then
 		pv $TAR | gzip $COMPRESSION_LEVEL > $COMP_TAR
 		rm $TAR
 		clear
+			if [ $SECONDARY_TARGET != "null" ]; then
+				cp $COMP_TAR $SECONDARY_TARGET
+			else
+				print "No secondary target"
+			fi
 		echo "Gzip is done compressing, exiting tar-pit"
 	else
 	  echo "Splitting tarball, please be patient"	#TODO; Add compression for individual chunks
-	  tarsplit "$TAR" $CHUNKS
+	  tarsplit "$TAR" $CHUNKS		#TODO; Verify chunk size
 	  rm "$TAR"
 	  echo "tarsplit has finished"
 	fi
 else
-	echo "This tar file will fit on one DVD, no reason to split, compressing at compression level $COMPRESSION_LEVEL"
+	echo "The file of $TAR_SIZE will be compressed at $COMPRESSION_LEVEL"
 	pv $TAR | gzip $COMPRESSION_LEVEL > $COMP_TAR
-	rm $TAR
+	rm "$TAR"
 	clear
-	echo "Gzip is done compressing, exiting tar-pit"
+	echo "Gzip is done compressing"
 fi
 
-#TODO; Verify chunk sizes


### PR DESCRIPTION
Added pacmanfile integration for arch users, when backing up ~/.config, allows a copy of all current installed programs
Secondary target allows tar-file to be stored in two static locations
fixed linter warnings